### PR TITLE
Add inventory, building, and escape menus

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,6 +1,7 @@
 from ursina import *
 from ursina.prefabs.first_person_controller import FirstPersonController
 import random
+import json
 
 
 class ResourceNode(Entity):
@@ -42,6 +43,7 @@ class Miner(Entity):
         if self.timer >= 10:
             resources[self.node.resource_type] += 1
             hud.update_text()
+            inventory_menu.update_text()
             self.timer = 0
 
 
@@ -71,6 +73,54 @@ class ResourceHUD(Entity):
         )
 
 
+
+class InventoryMenu(Entity):
+    """Display inventory contents."""
+    def __init__(self):
+        super().__init__(parent=camera.ui, enabled=False)
+        self.bg = Panel(scale=(0.4, 0.3), color=color.rgba(0,0,0,180))
+        self.text = Text(parent=self, text='', origin=(0,0), scale=2)
+        self.update_text()
+    def toggle(self):
+        self.enabled = not self.enabled
+        mouse.locked = not self.enabled
+        player.enabled = not self.enabled
+    def update_text(self):
+        lines=[f"{k.capitalize()}: {v}" for k,v in resources.items()]
+        self.text.text="\n".join(lines)
+
+class BuildingMenu(Entity):
+    """Menu for selecting buildings to place."""
+    def __init__(self):
+        super().__init__(parent=camera.ui, enabled=False)
+        self.bg = Panel(scale=(0.3,0.2), color=color.rgba(0,0,0,180))
+        self.miner_button=Button(text='Place Miner', parent=self, scale=(0.2,0.05), position=(0,0))
+        self.miner_button.on_click=self.place_miner
+    def toggle(self):
+        self.enabled = not self.enabled
+        mouse.locked = not self.enabled
+        player.enabled = not self.enabled
+    def place_miner(self):
+        global build_mode
+        build_mode=True
+        self.toggle()
+
+class EscapeMenu(Entity):
+    """Escape menu with game options."""
+    def __init__(self):
+        super().__init__(parent=camera.ui, enabled=False)
+        self.bg = Panel(scale=(0.3,0.3), color=color.rgba(0,0,0,180))
+        self.new_button=Button(text='New Game', parent=self, scale=(0.2,0.05), position=(0,0.1))
+        self.new_button.on_click=new_game
+        self.save_button=Button(text='Save Game', parent=self, scale=(0.2,0.05), position=(0,0))
+        self.save_button.on_click=save_game
+        self.exit_button=Button(text='Exit', parent=self, scale=(0.2,0.05), position=(0,-0.1))
+        self.exit_button.on_click=application.quit
+    def toggle(self):
+        self.enabled = not self.enabled
+        mouse.locked = not self.enabled
+        player.enabled = not self.enabled
+
 app = Ursina()
 
 # Ground
@@ -83,27 +133,60 @@ resources = {'stone': 0, 'iron': 0, 'copper': 0}
 nodes = generate_world()
 miners = []
 hud = ResourceHUD()
+inventory_menu = InventoryMenu()
+building_menu = BuildingMenu()
+escape_menu = EscapeMenu()
 
 build_mode = False
 
 
+def new_game():
+    global nodes, miners, resources
+    for m in miners:
+        destroy(m)
+    miners.clear()
+    for n in nodes:
+        destroy(n)
+    nodes = generate_world()
+    resources = {'stone': 0, 'iron': 0, 'copper': 0}
+    hud.update_text()
+    inventory_menu.update_text()
+
+
+def save_game():
+    with open('save.json', 'w') as f:
+        json.dump({'resources': resources}, f)
+    print('Game saved')
+
+
+
+def input(key):
+    if key == 'i':
+        inventory_menu.toggle()
+    if key == 'b':
+        building_menu.toggle()
+    if key == 'escape':
+        if escape_menu.enabled:
+            escape_menu.toggle()
+        elif inventory_menu.enabled:
+            inventory_menu.toggle()
+        elif building_menu.enabled:
+            building_menu.toggle()
+        else:
+            escape_menu.toggle()
+
+
 def update():
     global build_mode
-
-    if held_keys['b']:
-        build_mode = True
-    if held_keys['escape']:
-        build_mode = False
-
-    # Gather resources when pressing E near a node
+    if inventory_menu.enabled or building_menu.enabled or escape_menu.enabled:
+        return
     if held_keys['e']:
         for node in nodes:
             if distance(player.position, node.position) < 3 and node.miner is None:
                 resources[node.resource_type] += 1
                 hud.update_text()
+                inventory_menu.update_text()
                 break
-
-    # Place miner on node when in build mode and left mouse clicked
     if build_mode and mouse.left:
         for node in nodes:
             if distance(player.position, node.position) < 3 and node.miner is None:
@@ -112,11 +195,10 @@ def update():
                     for r in cost:
                         resources[r] -= cost[r]
                     hud.update_text()
+                    inventory_menu.update_text()
                     miner = Miner(node)
                     miners.append(miner)
                     node.miner = miner
                 break
-
-
 app.run()
 


### PR DESCRIPTION
## Summary
- implement `InventoryMenu`, `BuildingMenu`, and `EscapeMenu`
- add keybindings via new `input` handler
- allow saving and resetting the game
- update resource changes to refresh inventory HUD

## Testing
- `python3 -m py_compile game.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed3bcbcf48333ab5b336867da957e