### PR TITLE
Fix escape menu initialization order

### DIFF
--- a/game.py
+++ b/game.py
@@ -135,7 +135,6 @@ miners = []
 hud = ResourceHUD()
 inventory_menu = InventoryMenu()
 building_menu = BuildingMenu()
-escape_menu = EscapeMenu()
 
 build_mode = False
 
@@ -158,6 +157,7 @@ def save_game():
         json.dump({'resources': resources}, f)
     print('Game saved')
 
+escape_menu = EscapeMenu()
 
 
 def input(key):


### PR DESCRIPTION
## Summary
- ensure `escape_menu` is created after `new_game` and `save_game` functions are defined

## Testing
- `python -m py_compile game.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed680e540833391057677d9696a60