### PR TITLE
Add resource cost display in build menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # mygame
 test repo
+
+## Build Menu
+The build menu now shows resource costs for each building option.

--- a/game.py
+++ b/game.py
@@ -148,9 +148,9 @@ class BuildingMenu(Entity):
     def __init__(self):
         super().__init__(parent=camera.ui, enabled=False)
         self.bg = Panel(parent=self, scale=(0.3,0.2), color=color.rgba(0,0,0,180))
-        self.container_button=Button(text='Place Container', parent=self, scale=(0.2,0.05), position=(0,-0.06))
+        self.container_button=Button(text='Place Container\n(5 Stone)', parent=self, scale=(0.2,0.05), position=(0,-0.06))
         self.container_button.on_click=self.place_container
-        self.miner_button=Button(text='Place Miner', parent=self, scale=(0.2,0.05), position=(0,0))
+        self.miner_button=Button(text='Place Miner\n(5 Stone, 3 Iron, 2 Copper)', parent=self, scale=(0.2,0.05), position=(0,0))
         self.miner_button.on_click=self.place_miner
     def toggle(self):
         self.enabled = not self.enabled


### PR DESCRIPTION
## Summary
- show miner and container costs directly in Build Menu buttons
- document pricing info in README

## Testing
- `python -m py_compile game.py`
- `flake8 game.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eed44258c833386fb7564fc42bf49